### PR TITLE
Propagate request context

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,6 +18,8 @@ jobs:
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Not the same as GITHUB_TOKEN
+      # This token authenticates on behalf of the maintainer, not github actions itself
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       CC_SECRET: ${{ secrets.CC_SECRET }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -55,9 +57,13 @@ jobs:
         run: yarn codechecks
         working-directory: ./packages/io-ts-serverless-handler
         if: github.event_name != 'pull_request'
-      - name: Analyse Coverage
-        run: bash <(curl -s https://codecov.io/bash)
-        working-directory: ./packages/io-ts-serverless-handler
+      - name: Coveralls
+        uses: coverallsapp/github-action@v1.0.1
+        with:
+          # Not the same as GH_TOKEN
+          # See: https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./packages/io-ts-serverless-handler/coverage/lcov.info
       - name: Run Semantic Release
         run: yarn semantic-release
         working-directory: ./packages/io-ts-serverless-handler

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![npm](https://img.shields.io/npm/v/io-ts-serverless-handler)
 ![Node.js CI](https://github.com/NoxHarmonium/io-ts-serverless-handler/workflows/Node.js%20CI/badge.svg)
-[![codecov](https://codecov.io/gh/NoxHarmonium/io-ts-serverless-handler/branch/master/graph/badge.svg)](https://codecov.io/gh/NoxHarmonium/io-ts-serverless-handler)
+[![Coverage Status](https://coveralls.io/repos/github/NoxHarmonium/io-ts-serverless-handler/badge.svg?branch=master)](https://coveralls.io/github/NoxHarmonium/io-ts-serverless-handler?branch=master)
 [![type-coverage](https://img.shields.io/badge/dynamic/json.svg?label=type-coverage&prefix=%E2%89%A5&suffix=%&query=$.typeCoverage.atLeast&uri=https%3A%2F%2Fraw.githubusercontent.com%2FNoxHarmonium%2Fio-ts-serverless-handler%2Fmaster%2Fpackage.json)](https://github.com/plantain-00/type-coverage)
 ![licence](https://img.shields.io/npm/l/io-ts-serverless-handler)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)

--- a/packages/io-ts-serverless-handler-example/package.json
+++ b/packages/io-ts-serverless-handler-example/package.json
@@ -18,7 +18,8 @@
     "io-ts-types": "^0.5.6",
     "lodash": "^4.17.15",
     "monocle-ts": "^2.1.0",
-    "newtype-ts": "^0.3.4"
+    "newtype-ts": "^0.3.4",
+    "source-map-support": "^0.5.16"
   },
   "author": "Sean Dawson <contact@seandawson.info>",
   "license": "Apache-2.0",

--- a/packages/io-ts-serverless-handler-example/scripts/integration-test.sh
+++ b/packages/io-ts-serverless-handler-example/scripts/integration-test.sh
@@ -25,8 +25,14 @@ aws sts get-caller-identity > /dev/null || {
 }
 
 cleanup() {
+  EXIT_STATUS=$?  # Ensure original exit status is propagated
+  echo 'Logs for listProducts:'
+  yarn sls logs -s "$STAGE" -f listProducts || true
+  echo 'Logs for getProduct:'
+  yarn sls logs -s "$STAGE" -f getProduct || true
   echo 'Cleaning up!'
   yarn sls remove -s "$STAGE" --verbose
+  exit "$EXIT_STATUS"
 }
 
 pushd "$CURRENT_DIR/.."

--- a/packages/io-ts-serverless-handler-example/src/handler.ts
+++ b/packages/io-ts-serverless-handler-example/src/handler.ts
@@ -16,11 +16,17 @@ export const listProducts = codecHandler(
       pageSize: NumberFromString
     })
   },
-  async ({ queryStringParameters: { pageNumber, pageSize } }) => {
+  async (
+    { queryStringParameters: { pageNumber, pageSize } },
+    { awsRequestId }
+  ) => {
     const resolvedPageSize = pageSize === undefined ? 10 : pageSize;
     const resolvedPageNumber = pageNumber === undefined ? 0 : pageNumber;
     const productPage = chunk(products, resolvedPageSize)[resolvedPageNumber];
-    return productPage === undefined ? [] : productPage;
+    return {
+      awsRequestId,
+      data: productPage ?? []
+    };
   }
 );
 
@@ -30,11 +36,14 @@ export const getProduct = codecHandler(
       id: NumberFromString
     })
   },
-  async ({ pathParameters: { id } }) => {
+  async ({ pathParameters: { id } }, { awsRequestId }) => {
     const productPage = products[id];
     if (productPage === undefined) {
       throw new Error("product not found");
     }
-    return productPage;
+    return {
+      awsRequestId,
+      data: productPage
+    };
   }
 );

--- a/packages/io-ts-serverless-handler/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/io-ts-serverless-handler/src/__tests__/__snapshots__/index.test.ts.snap
@@ -16,6 +16,13 @@ Object {
 }
 `;
 
+exports[`when using default options when exhaustively specifying all possible properties should be able to parse a full payload correctly 1`] = `
+Object {
+  "body": "{\\"requiredHeader\\":123,\\"optionalHeader\\":false,\\"requiredMVH\\":[\\"1970-01-01T00:00:00.000Z\\",\\"1970-01-01T00:01:40.000Z\\"],\\"optionalMVH\\":[\\"abc\\",null,\\"def\\",null,null],\\"requiredPathParamA\\":\\"string\\",\\"requiredPathParamB\\":\\"1970-01-01T00:16:39.999Z\\",\\"optionalPathParam\\":321.123,\\"requiredQueryStringA\\":\\"abc\\",\\"requiredQueryStringB\\":[1,2,3],\\"optionalQueryString\\":\\"123abc\\",\\"requiredMVQueryString\\":[true,false,true],\\"optionalMVQueryString\\":[{\\"a\\":true},false],\\"requiredStageVariable\\":\\"asdf\\",\\"optionalStageVariable\\":{\\"a\\":{\\"b\\":{\\"c\\":4}}},\\"body\\":{\\"some\\":\\"string\\"}}",
+  "statusCode": 200,
+}
+`;
+
 exports[`when using default options when providing extra parameters not defined in the codec should  not strip the extra parameters 1`] = `
 Object {
   "body": "{\\"headers\\":{},\\"multiValueHeaders\\":{},\\"pathParameters\\":{\\"something\\":\\"true\\"},\\"queryStringParameters\\":{\\"pageNumber\\":4,\\"extraParameter\\":\\"hello\\"},\\"multiValueQueryStringParameters\\":{},\\"stageVariables\\":{},\\"body\\":null}",

--- a/packages/io-ts-serverless-handler/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/io-ts-serverless-handler/src/__tests__/__snapshots__/index.test.ts.snap
@@ -11,14 +11,14 @@ Object {
 
 exports[`when providing custom handlers when the payload is valid should succeed 1`] = `
 Object {
-  "body": "{\\"result\\":{\\"hello\\":\\"there\\",\\"params\\":{\\"pageNumber\\":4}},\\"custom\\":true}",
+  "body": "{\\"result\\":{\\"hello\\":\\"there\\",\\"params\\":{\\"pageNumber\\":4},\\"awsRequestId\\":\\"mock ID\\"},\\"custom\\":true}",
   "statusCode": 200,
 }
 `;
 
 exports[`when using default options when exhaustively specifying all possible properties should be able to parse a full payload correctly 1`] = `
 Object {
-  "body": "{\\"requiredHeader\\":123,\\"optionalHeader\\":false,\\"requiredMVH\\":[\\"1970-01-01T00:00:00.000Z\\",\\"1970-01-01T00:01:40.000Z\\"],\\"optionalMVH\\":[\\"abc\\",null,\\"def\\",null,null],\\"requiredPathParamA\\":\\"string\\",\\"requiredPathParamB\\":\\"1970-01-01T00:16:39.999Z\\",\\"optionalPathParam\\":321.123,\\"requiredQueryStringA\\":\\"abc\\",\\"requiredQueryStringB\\":[1,2,3],\\"optionalQueryString\\":\\"123abc\\",\\"requiredMVQueryString\\":[true,false,true],\\"optionalMVQueryString\\":[{\\"a\\":true},false],\\"requiredStageVariable\\":\\"asdf\\",\\"optionalStageVariable\\":{\\"a\\":{\\"b\\":{\\"c\\":4}}},\\"body\\":{\\"some\\":\\"string\\"}}",
+  "body": "{\\"requiredHeader\\":123,\\"optionalHeader\\":false,\\"requiredMVH\\":[\\"1970-01-01T00:00:00.000Z\\",\\"1970-01-01T00:01:40.000Z\\"],\\"optionalMVH\\":[\\"abc\\",null,\\"def\\",null,null],\\"requiredPathParamA\\":\\"string\\",\\"requiredPathParamB\\":\\"1970-01-01T00:16:39.999Z\\",\\"optionalPathParam\\":321.123,\\"requiredQueryStringA\\":\\"abc\\",\\"requiredQueryStringB\\":[1,2,3],\\"optionalQueryString\\":\\"123abc\\",\\"requiredMVQueryString\\":[true,false,true],\\"optionalMVQueryString\\":[{\\"a\\":true},false],\\"requiredStageVariable\\":\\"asdf\\",\\"optionalStageVariable\\":{\\"a\\":{\\"b\\":{\\"c\\":4}}},\\"body\\":{\\"some\\":\\"string\\"},\\"awsRequestId\\":\\"mock ID\\"}",
   "statusCode": 200,
 }
 `;
@@ -41,7 +41,7 @@ Object {
 
 exports[`when using default options when the codec definition has a body when the payload is valid should succeed 1`] = `
 Object {
-  "body": "{\\"pageSize\\":6,\\"body\\":{\\"message\\":\\"hello\\"}}",
+  "body": "{\\"pageSize\\":6,\\"body\\":{\\"message\\":\\"hello\\"},\\"awsRequestId\\":\\"mock ID\\"}",
   "statusCode": 200,
 }
 `;
@@ -76,14 +76,14 @@ Object {
 
 exports[`when using strict mode when providing extra parameters not defined in the codec should strip the extra parameters 1`] = `
 Object {
-  "body": "{\\"queryStringParameters\\":{\\"pageNumber\\":4}}",
+  "body": "{\\"params\\":{\\"queryStringParameters\\":{\\"pageNumber\\":4}},\\"context\\":{\\"callbackWaitsForEmptyEventLoop\\":false,\\"functionName\\":\\"mockFunction\\",\\"functionVersion\\":\\"2\\",\\"invokedFunctionArn\\":\\"arn:aws:lambda:ap-southeast-2:1234456776:function:\${FunctionName}\\",\\"memoryLimitInMB\\":\\"1024\\",\\"awsRequestId\\":\\"mock ID\\",\\"logGroupName\\":\\"group name\\",\\"logStreamName\\":\\"stream name\\",\\"identity\\":{\\"cognitoIdentityId\\":\\"mock-identity-id\\",\\"cognitoIdentityPoolId\\":\\"mock-identity-pool-id\\"},\\"clientContext\\":{\\"client\\":{\\"installationId\\":\\"string\\",\\"appTitle\\":\\"string\\",\\"appVersionName\\":\\"string\\",\\"appVersionCode\\":\\"string\\",\\"appPackageName\\":\\"string\\"},\\"Custom\\":\\"some custom\\",\\"env\\":{\\"platformVersion\\":\\"string\\",\\"platform\\":\\"string\\",\\"make\\":\\"string\\",\\"model\\":\\"string\\",\\"locale\\":\\"string\\"}}}}",
   "statusCode": 200,
 }
 `;
 
 exports[`when using strict mode when providing the exact required input should succeed 1`] = `
 Object {
-  "body": "{\\"queryStringParameters\\":{\\"pageNumber\\":4}}",
+  "body": "{\\"params\\":{\\"queryStringParameters\\":{\\"pageNumber\\":4}},\\"context\\":{\\"callbackWaitsForEmptyEventLoop\\":false,\\"functionName\\":\\"mockFunction\\",\\"functionVersion\\":\\"2\\",\\"invokedFunctionArn\\":\\"arn:aws:lambda:ap-southeast-2:1234456776:function:\${FunctionName}\\",\\"memoryLimitInMB\\":\\"1024\\",\\"awsRequestId\\":\\"mock ID\\",\\"logGroupName\\":\\"group name\\",\\"logStreamName\\":\\"stream name\\",\\"identity\\":{\\"cognitoIdentityId\\":\\"mock-identity-id\\",\\"cognitoIdentityPoolId\\":\\"mock-identity-pool-id\\"},\\"clientContext\\":{\\"client\\":{\\"installationId\\":\\"string\\",\\"appTitle\\":\\"string\\",\\"appVersionName\\":\\"string\\",\\"appVersionCode\\":\\"string\\",\\"appPackageName\\":\\"string\\"},\\"Custom\\":\\"some custom\\",\\"env\\":{\\"platformVersion\\":\\"string\\",\\"platform\\":\\"string\\",\\"make\\":\\"string\\",\\"model\\":\\"string\\",\\"locale\\":\\"string\\"}}}}",
   "statusCode": 200,
 }
 `;

--- a/packages/io-ts-serverless-handler/src/types.ts
+++ b/packages/io-ts-serverless-handler/src/types.ts
@@ -1,20 +1,30 @@
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import * as t from "io-ts";
-
-/**
- * The parts of APIGatewayProxyEvent that we want to validate
- */
-export type ExtractableParameters = Pick<
+import {
   APIGatewayProxyEvent,
-  // tslint:disable-next-line: max-union-size
+  APIGatewayProxyResult,
+  Handler
+} from "aws-lambda";
+import * as t from "io-ts";
+import { Except } from "type-fest";
+
+// tslint:disable-next-line: max-union-size
+type ExtractableKeys =
   | "headers"
   | "multiValueHeaders"
   | "pathParameters"
   | "queryStringParameters"
   | "multiValueQueryStringParameters"
   | "stageVariables"
-  | "body"
->;
+  | "body";
+
+/**
+ * The parts of APIGatewayProxyEvent that we want to validate
+ */
+export type ExtractableParameters = Pick<APIGatewayProxyEvent, ExtractableKeys>;
+
+/**
+ * The parts of APIGatewayProxyEvent that we just want to pass through
+ */
+export type PassableParameters = Except<APIGatewayProxyEvent, ExtractableKeys>;
 
 /**
  * The most general case of codec that can be assigned to an event map
@@ -46,9 +56,10 @@ export type ValueMap<EventMap extends EventMapBase> = {
  * The type of function that handled the decoded event properties
  * and returns a value that will be transformed and sent back to the client
  */
-export type HandlerFunction<EventMap extends EventMapBase, ReturnType> = (
-  values: ValueMap<EventMap>
-) => Promise<ReturnType>;
+export type HandlerFunction<
+  EventMap extends EventMapBase,
+  ReturnType
+> = Handler<PassableParameters & ValueMap<EventMap>, ReturnType>;
 
 /**
  * Takes the error output of a io-ts decode function and transforms it to

--- a/packages/io-ts-serverless-handler/src/utils.ts
+++ b/packages/io-ts-serverless-handler/src/utils.ts
@@ -1,5 +1,8 @@
-// Remove all keys with null values
-// Thanks: https://stackoverflow.com/a/57625661/1153203
+/**
+ * Remove all keys with null values
+ *
+ * Thanks: https://stackoverflow.com/a/57625661/1153203
+ */
 export const removeEmpty = (obj: {}): {} =>
   Object.entries(obj).reduce(
     (a, [k, v]) => (v == null ? a : { ...a, [k]: v }),


### PR DESCRIPTION
Before this change, only the lambda event was passed through to the handler.
This changes it to also pass through the context object.